### PR TITLE
Fix download link for 32bit QGIS download

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
               <li><a href="downloads/jre_8u11-windows-x64.exe">Java JRE (64-bit Windows)</a></li>
               <li><a href="downloads/jre_8u11-macosx-x64.dmg">Java JRE (macOS)</a></li>
               <li><a href="downloads/josm.jar">JOSM</a></li>
-              <li><a href="downloads/QGIS-OSGeo4W-2.18.0-1-Setup-x86">QGIS (32-bit Windows)</a></li>
+              <li><a href="downloads/QGIS-OSGeo4W-2.18.0-1-Setup-x86.exe">QGIS (32-bit Windows)</a></li>
               <li><a href="downloads/QGIS-OSGeo4W-2.18.0-1-Setup-x86_64.exe">QGIS (64-bit Windows)</a></li>
               <li><a href="downloads/QGIS-2.18.0-1.dmg">QGIS (macOS)</a></li>
             </ul>


### PR DESCRIPTION
Was missing the .exe on the end of the link.